### PR TITLE
Remove token secrets and replace gitea context references

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,15 +6,14 @@ inputs:
   gitea-url:
     description: 'Gitea server URL'
     required: true
-    default: ${{ gitea.server_url }}
+    default: ${{ github.server_url }}
   gitea-token:
     description: 'Gitea authentication token'
     required: true
-    default: ${{ secrets.GITEA_TOKEN }}
   gitea-repository:
     description: 'Repository in format owner/repo'
     required: false
-    default: ${{ gitea.repository }}
+    default: ${{ github.repository }}
   exclude-patterns:
     description: 'Comma-separated list of glob patterns to exclude flake.nix files'
     required: false


### PR DESCRIPTION
Act recently started to validate actions more strictly:

- Composite actions are not allowed to access the secret context, see https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#secrets-context
- gitea context is not available in act by default (and also not on forgejo). Switched to github, so that the action should work in all act runners.