### PR TITLE
flake: add mypy check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+result

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,14 @@
             ]
           );
 
+          mypyEnv = python.withPackages (
+            ps: with ps; [
+              config.packages.update-flake-inputs
+              mypy
+              pytest
+            ]
+          );
+
           mkPytestCheck =
             {
               impure ? false,
@@ -86,6 +94,17 @@
 
           checks.pytest = mkPytestCheck { };
           checks.pytest-impure = mkPytestCheck { impure = true; };
+
+          checks.mypy = pkgs.runCommand "mypy" { nativeBuildInputs = [ mypyEnv ]; } ''
+            cp -r ${./.} ./src
+            chmod +w -R ./src
+            cd ./src
+
+            export HOME=$TMPDIR
+            mypy .
+
+            touch $out
+          '';
 
           treefmt = {
             projectRootFile = "flake.nix";


### PR DESCRIPTION
mypy was previously enforced only by the GitHub Actions test workflow, which was removed when buildbot took over CI. Add it as a flake check so mypy errors fail the build on every PR.

treefmt-nix's mypy module was considered but its include globs (`src/*.py`) do not recurse into nested packages like `src/update_flake_inputs/`, so it never actually typechecks anything in this layout. A small `runCommand` derivation is simpler and correct.

Also ignore the default `result` symlink from `nix build`.