### PR TITLE
Don't force push with no changes at all

### DIFF
--- a/src/update_flake_inputs/gitea_service.py
+++ b/src/update_flake_inputs/gitea_service.py
@@ -23,6 +23,24 @@ logger = logging.getLogger(__name__)
 HTTP_CONFLICT = 409
 
 
+def _commit_identity(worktree_path: Path, rev: str) -> tuple[str, str, str]:
+    """Return (tree, parents, message) for a commit.
+
+    Two commits with the same identity differ at most in author/committer
+    timestamps (and name/email), so a force push between them would only
+    rewrite metadata without changing the branch's effective state.
+    """
+    output = subprocess.run(
+        ["git", "log", "-1", "--format=%T%n%P%n%B", rev],
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    tree, parents, message = output.split("\n", 2)
+    return tree, parents, message
+
+
 @dataclass
 class Branch:
     """Represents a Git branch."""
@@ -272,6 +290,32 @@ class GiteaService:
             env=env,
             check=True,
         )
+
+        # Check if the remote branch's tip is the same commit modulo timestamps.
+        # We compare tree + parents + message: if any of those differ we still
+        # want to force push (e.g. history diverged, or message changed), but
+        # if only the author/committer dates differ then the new commit adds
+        # nothing of value and we skip the push to avoid noisy force pushes.
+        local_identity = _commit_identity(worktree_path, "HEAD")
+
+        # Fetch the remote branch (may not exist yet)
+        fetch_result = subprocess.run(
+            ["git", "fetch", "origin", branch_name],
+            cwd=worktree_path,
+            capture_output=True,
+            check=False,
+        )
+
+        if fetch_result.returncode == 0:
+            remote_identity = _commit_identity(worktree_path, f"origin/{branch_name}")
+
+            if local_identity == remote_identity:
+                logger.info(
+                    "Branch %s already at an equivalent commit "
+                    "(only timestamps would change), skipping push",
+                    branch_name,
+                )
+                return True
 
         # Push to remote
         subprocess.run(

--- a/tests/test_gitea_service.py
+++ b/tests/test_gitea_service.py
@@ -297,19 +297,3 @@ class TestCommitChangesSkipsRedundantPush:
         finally:
             os.chdir(original_cwd)
 
-    def test_pushes_when_remote_branch_does_not_exist(self, tmp_path: Path) -> None:
-        """First push for a new branch should succeed normally."""
-        work, _remote = _setup_repo_with_remote(tmp_path)
-        svc = OfflineGiteaService()
-        original_cwd = Path.cwd()
-        os.chdir(work)
-        try:
-            wt = _make_worktree(work, "update-new", tmp_path)
-            (wt / "data.txt").write_text("v2\n")
-            assert svc.commit_changes("update-new", "Update new", wt) is True
-
-            # Remote branch should now exist
-            sha = _git(["rev-parse", "origin/update-new"], cwd=work).strip()
-            assert sha
-        finally:
-            os.chdir(original_cwd)

--- a/tests/test_gitea_service.py
+++ b/tests/test_gitea_service.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -132,6 +133,14 @@ class OfflineGiteaService(GiteaService):
         """Skip token validation in offline tests."""
 
 
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "Test User",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "Test User",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+}
+
+
 def _git(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
     """Run a git command and return its stdout."""
     result = subprocess.run(
@@ -145,42 +154,36 @@ def _git(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
     return result.stdout
 
 
-def _setup_repo_with_remote(tmp_path: Path) -> tuple[Path, Path]:
-    """Initialize a working repo with a bare remote. Returns (work, remote)."""
+@pytest.fixture
+def work_repo(tmp_path: Path) -> Iterator[Path]:
+    """Initialize a working repo with a bare remote, chdir into it, restore after."""
     work = tmp_path / "work"
     work.mkdir()
     remote = tmp_path / "remote.git"
     remote.mkdir()
 
-    git_env = {
-        **os.environ,
-        "GIT_AUTHOR_NAME": "Test User",
-        "GIT_AUTHOR_EMAIL": "test@example.com",
-        "GIT_COMMITTER_NAME": "Test User",
-        "GIT_COMMITTER_EMAIL": "test@example.com",
-    }
+    env = {**os.environ, **_GIT_ENV}
 
     _git(["init", "--bare"], cwd=remote)
     _git(["init", "-b", "main"], cwd=work)
     (work / "README.md").write_text("hello\n")
     _git(["add", "."], cwd=work)
-    _git(["commit", "-m", "Initial commit"], cwd=work, env=git_env)
+    _git(["commit", "-m", "Initial commit"], cwd=work, env=env)
     _git(["remote", "add", "origin", str(remote)], cwd=work)
     _git(["push", "-u", "origin", "main"], cwd=work)
 
-    return work, remote
+    original_cwd = Path.cwd()
+    os.chdir(work)
+    try:
+        yield work
+    finally:
+        os.chdir(original_cwd)
 
 
-def _make_worktree(work: Path, branch: str, tmp_path: Path) -> Path:
-    """Create a worktree based on origin/main for the given branch.
-
-    If a local branch with the same name already exists (e.g. from a
-    previously-removed worktree) it is deleted first so we always start
-    from a fresh origin/main base.
-    """
-    wt_path = tmp_path / f"wt-{branch}-{os.urandom(4).hex()}"
+def _make_worktree(work: Path, branch: str) -> Path:
+    """Create a worktree based on origin/main for the given branch."""
+    wt_path = work.parent / f"wt-{branch}"
     _git(["fetch", "origin", "main"], cwd=work)
-    # Delete existing local branch if present so -b can re-create it
     subprocess.run(
         ["git", "branch", "-D", branch],
         cwd=work,
@@ -199,101 +202,66 @@ class TestCommitChangesSkipsRedundantPush:
 
     def test_skips_push_when_only_timestamps_differ(
         self,
-        tmp_path: Path,
+        work_repo: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Second identical update should not move the remote branch SHA.
-
-        The two commits must have different author/committer dates so that
-        without the skip logic they would resolve to distinct SHAs and the
-        force push would visibly advance the remote branch.
-        """
-        work, _remote = _setup_repo_with_remote(tmp_path)
+        """Second identical update should not move the remote branch SHA."""
         svc = OfflineGiteaService()
-        original_cwd = Path.cwd()
-        os.chdir(work)
-        try:
-            # First run: change a file, commit, push at one date
-            monkeypatch.setenv("GIT_AUTHOR_DATE", "2025-01-01T00:00:00+0000")
-            monkeypatch.setenv("GIT_COMMITTER_DATE", "2025-01-01T00:00:00+0000")
-            wt1 = _make_worktree(work, "update-foo", tmp_path)
-            (wt1 / "data.txt").write_text("v2\n")
-            assert svc.commit_changes("update-foo", "Update foo", wt1) is True
 
-            first_sha = _git(["rev-parse", "origin/update-foo"], cwd=work).strip()
-            _git(["worktree", "remove", "--force", str(wt1)], cwd=work)
+        monkeypatch.setenv("GIT_AUTHOR_DATE", "2025-01-01T00:00:00+0000")
+        monkeypatch.setenv("GIT_COMMITTER_DATE", "2025-01-01T00:00:00+0000")
+        wt1 = _make_worktree(work_repo, "update-foo")
+        (wt1 / "data.txt").write_text("v2\n")
+        assert svc.commit_changes("update-foo", "Update foo", wt1) is True
 
-            # Second run: produce the same file change but at a later date.
-            monkeypatch.setenv("GIT_AUTHOR_DATE", "2025-02-02T00:00:00+0000")
-            monkeypatch.setenv("GIT_COMMITTER_DATE", "2025-02-02T00:00:00+0000")
-            wt2 = _make_worktree(work, "update-foo", tmp_path)
-            (wt2 / "data.txt").write_text("v2\n")
+        first_sha = _git(["rev-parse", "origin/update-foo"], cwd=work_repo).strip()
+        _git(["worktree", "remove", "--force", str(wt1)], cwd=work_repo)
 
-            assert svc.commit_changes("update-foo", "Update foo", wt2) is True
+        monkeypatch.setenv("GIT_AUTHOR_DATE", "2025-02-02T00:00:00+0000")
+        monkeypatch.setenv("GIT_COMMITTER_DATE", "2025-02-02T00:00:00+0000")
+        wt2 = _make_worktree(work_repo, "update-foo")
+        (wt2 / "data.txt").write_text("v2\n")
+        assert svc.commit_changes("update-foo", "Update foo", wt2) is True
 
-            # Remote SHA must be unchanged - no force push happened
-            second_sha = _git(["rev-parse", "origin/update-foo"], cwd=work).strip()
-            assert first_sha == second_sha
-        finally:
-            os.chdir(original_cwd)
+        second_sha = _git(["rev-parse", "origin/update-foo"], cwd=work_repo).strip()
+        assert first_sha == second_sha
 
-    def test_pushes_when_message_differs(self, tmp_path: Path) -> None:
-        """Different commit message should still force push (history differs)."""
-        work, _remote = _setup_repo_with_remote(tmp_path)
+    def test_pushes_when_message_differs(self, work_repo: Path) -> None:
+        """Different commit message should still force push."""
         svc = OfflineGiteaService()
-        original_cwd = Path.cwd()
-        os.chdir(work)
-        try:
-            wt1 = _make_worktree(work, "update-bar", tmp_path)
-            (wt1 / "data.txt").write_text("v2\n")
-            assert svc.commit_changes("update-bar", "Update bar", wt1) is True
-            first_sha = _git(["rev-parse", "origin/update-bar"], cwd=work).strip()
-            _git(["worktree", "remove", "--force", str(wt1)], cwd=work)
 
-            wt2 = _make_worktree(work, "update-bar", tmp_path)
-            (wt2 / "data.txt").write_text("v2\n")
-            assert svc.commit_changes("update-bar", "Update bar v2", wt2) is True
+        wt1 = _make_worktree(work_repo, "update-bar")
+        (wt1 / "data.txt").write_text("v2\n")
+        assert svc.commit_changes("update-bar", "Update bar", wt1) is True
+        first_sha = _git(["rev-parse", "origin/update-bar"], cwd=work_repo).strip()
+        _git(["worktree", "remove", "--force", str(wt1)], cwd=work_repo)
 
-            second_sha = _git(["rev-parse", "origin/update-bar"], cwd=work).strip()
-            assert first_sha != second_sha
-        finally:
-            os.chdir(original_cwd)
+        wt2 = _make_worktree(work_repo, "update-bar")
+        (wt2 / "data.txt").write_text("v2\n")
+        assert svc.commit_changes("update-bar", "Update bar v2", wt2) is True
 
-    def test_pushes_when_parent_differs(self, tmp_path: Path) -> None:
+        second_sha = _git(["rev-parse", "origin/update-bar"], cwd=work_repo).strip()
+        assert first_sha != second_sha
+
+    def test_pushes_when_parent_differs(self, work_repo: Path) -> None:
         """Same tree+message but different parent should still force push."""
-        work, _remote = _setup_repo_with_remote(tmp_path)
         svc = OfflineGiteaService()
-        git_env = {
-            **os.environ,
-            "GIT_AUTHOR_NAME": "Test User",
-            "GIT_AUTHOR_EMAIL": "test@example.com",
-            "GIT_COMMITTER_NAME": "Test User",
-            "GIT_COMMITTER_EMAIL": "test@example.com",
-        }
-        original_cwd = Path.cwd()
-        os.chdir(work)
-        try:
-            # First run from current main
-            wt1 = _make_worktree(work, "update-baz", tmp_path)
-            (wt1 / "data.txt").write_text("v2\n")
-            assert svc.commit_changes("update-baz", "Update baz", wt1) is True
-            first_sha = _git(["rev-parse", "origin/update-baz"], cwd=work).strip()
-            _git(["worktree", "remove", "--force", str(wt1)], cwd=work)
+        env = {**os.environ, **_GIT_ENV}
 
-            # Advance main with an unrelated commit
-            (work / "other.txt").write_text("unrelated\n")
-            _git(["add", "."], cwd=work)
-            _git(["commit", "-m", "Unrelated"], cwd=work, env=git_env)
-            _git(["push", "origin", "main"], cwd=work)
+        wt1 = _make_worktree(work_repo, "update-baz")
+        (wt1 / "data.txt").write_text("v2\n")
+        assert svc.commit_changes("update-baz", "Update baz", wt1) is True
+        first_sha = _git(["rev-parse", "origin/update-baz"], cwd=work_repo).strip()
+        _git(["worktree", "remove", "--force", str(wt1)], cwd=work_repo)
 
-            # Second run now bases off the new main - same tree contents
-            # for data.txt but different parent
-            wt2 = _make_worktree(work, "update-baz", tmp_path)
-            (wt2 / "data.txt").write_text("v2\n")
-            assert svc.commit_changes("update-baz", "Update baz", wt2) is True
+        (work_repo / "other.txt").write_text("unrelated\n")
+        _git(["add", "."], cwd=work_repo)
+        _git(["commit", "-m", "Unrelated"], cwd=work_repo, env=env)
+        _git(["push", "origin", "main"], cwd=work_repo)
 
-            second_sha = _git(["rev-parse", "origin/update-baz"], cwd=work).strip()
-            assert first_sha != second_sha
-        finally:
-            os.chdir(original_cwd)
+        wt2 = _make_worktree(work_repo, "update-baz")
+        (wt2 / "data.txt").write_text("v2\n")
+        assert svc.commit_changes("update-baz", "Update baz", wt2) is True
 
+        second_sha = _git(["rev-parse", "origin/update-baz"], cwd=work_repo).strip()
+        assert first_sha != second_sha

--- a/tests/test_gitea_service.py
+++ b/tests/test_gitea_service.py
@@ -57,16 +57,6 @@ def _make_service(
 
 
 class TestMergeStyleInit:
-    def test_default_fetches_repo_merge_style(self) -> None:
-        """Test that 'default' resolves to the repo's default_merge_style."""
-        svc = _make_service(default_merge_style="rebase")
-        assert svc.merge_style == "rebase"
-
-    def test_default_fetches_squash_merge_style(self) -> None:
-        """Test that 'default' resolves to squash when repo is configured for it."""
-        svc = _make_service(default_merge_style="squash")
-        assert svc.merge_style == "squash"
-
     def test_default_falls_back_to_merge(self) -> None:
         """When repo response lacks default_merge_style, fall back to merge."""
         responses: dict[tuple[str, str], Any] = {
@@ -112,9 +102,10 @@ class TestMergeStyleInRequest:
         assert data is not None
         assert "Do" not in data
 
-    def test_default_sends_repo_merge_style(self) -> None:
-        """Test that 'default' resolves to repo default and sends it as Do."""
+    def test_default_resolves_and_sends_repo_merge_style(self) -> None:
+        """Test that 'default' resolves to repo default_merge_style and sends it as Do."""
         svc = _make_service(default_merge_style="squash")
+        assert svc.merge_style == "squash"
         svc.responses[("POST", "/repos/test-owner/test-repo/pulls/1/merge")] = {}
 
         svc._merge_pull_request(1)  # noqa: SLF001

--- a/tests/test_gitea_service.py
+++ b/tests/test_gitea_service.py
@@ -1,7 +1,12 @@
 """Tests for GiteaService merge style handling."""
 
+import os
+import subprocess
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
+
+import pytest
 
 from update_flake_inputs.gitea_service import GiteaService
 
@@ -117,3 +122,203 @@ class TestMergeStyleInRequest:
         _method, _endpoint, data = svc.requests[-1]
         assert data is not None
         assert data["Do"] == "squash"
+
+
+@dataclass
+class OfflineGiteaService(GiteaService):
+    """GiteaService that skips token validation for offline tests."""
+
+    api_url: str = "https://gitea.example.com"
+    token: str = "test-token"  # noqa: S105
+    owner: str = "test-owner"
+    repo: str = "test-repo"
+
+    def __post_init__(self) -> None:
+        """Skip token validation in offline tests."""
+        self.api_url = self.api_url.rstrip("/")
+
+    def _validate_token(self) -> None:  # pragma: no cover - intentionally a no-op
+        """Skip token validation in offline tests."""
+
+
+def _git(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
+    """Run a git command and return its stdout."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    return result.stdout
+
+
+def _setup_repo_with_remote(tmp_path: Path) -> tuple[Path, Path]:
+    """Initialize a working repo with a bare remote. Returns (work, remote)."""
+    work = tmp_path / "work"
+    work.mkdir()
+    remote = tmp_path / "remote.git"
+    remote.mkdir()
+
+    git_env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test User",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test User",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+    _git(["init", "--bare"], cwd=remote)
+    _git(["init", "-b", "main"], cwd=work)
+    (work / "README.md").write_text("hello\n")
+    _git(["add", "."], cwd=work)
+    _git(["commit", "-m", "Initial commit"], cwd=work, env=git_env)
+    _git(["remote", "add", "origin", str(remote)], cwd=work)
+    _git(["push", "-u", "origin", "main"], cwd=work)
+
+    return work, remote
+
+
+def _make_worktree(work: Path, branch: str, tmp_path: Path) -> Path:
+    """Create a worktree based on origin/main for the given branch.
+
+    If a local branch with the same name already exists (e.g. from a
+    previously-removed worktree) it is deleted first so we always start
+    from a fresh origin/main base.
+    """
+    wt_path = tmp_path / f"wt-{branch}-{os.urandom(4).hex()}"
+    _git(["fetch", "origin", "main"], cwd=work)
+    # Delete existing local branch if present so -b can re-create it
+    subprocess.run(
+        ["git", "branch", "-D", branch],
+        cwd=work,
+        capture_output=True,
+        check=False,
+    )
+    _git(
+        ["worktree", "add", str(wt_path), "-b", branch, "origin/main"],
+        cwd=work,
+    )
+    return wt_path
+
+
+class TestCommitChangesSkipsRedundantPush:
+    """Verify commit_changes skips force push when only timestamps would change."""
+
+    def test_skips_push_when_only_timestamps_differ(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Second identical update should not move the remote branch SHA.
+
+        The two commits must have different author/committer dates so that
+        without the skip logic they would resolve to distinct SHAs and the
+        force push would visibly advance the remote branch.
+        """
+        work, _remote = _setup_repo_with_remote(tmp_path)
+        svc = OfflineGiteaService()
+        original_cwd = Path.cwd()
+        os.chdir(work)
+        try:
+            # First run: change a file, commit, push at one date
+            monkeypatch.setenv("GIT_AUTHOR_DATE", "2025-01-01T00:00:00+0000")
+            monkeypatch.setenv("GIT_COMMITTER_DATE", "2025-01-01T00:00:00+0000")
+            wt1 = _make_worktree(work, "update-foo", tmp_path)
+            (wt1 / "data.txt").write_text("v2\n")
+            assert svc.commit_changes("update-foo", "Update foo", wt1) is True
+
+            first_sha = _git(["rev-parse", "origin/update-foo"], cwd=work).strip()
+            _git(["worktree", "remove", "--force", str(wt1)], cwd=work)
+
+            # Second run: produce the same file change but at a later date.
+            monkeypatch.setenv("GIT_AUTHOR_DATE", "2025-02-02T00:00:00+0000")
+            monkeypatch.setenv("GIT_COMMITTER_DATE", "2025-02-02T00:00:00+0000")
+            wt2 = _make_worktree(work, "update-foo", tmp_path)
+            (wt2 / "data.txt").write_text("v2\n")
+
+            assert svc.commit_changes("update-foo", "Update foo", wt2) is True
+
+            # Remote SHA must be unchanged - no force push happened
+            second_sha = _git(["rev-parse", "origin/update-foo"], cwd=work).strip()
+            assert first_sha == second_sha
+        finally:
+            os.chdir(original_cwd)
+
+    def test_pushes_when_message_differs(self, tmp_path: Path) -> None:
+        """Different commit message should still force push (history differs)."""
+        work, _remote = _setup_repo_with_remote(tmp_path)
+        svc = OfflineGiteaService()
+        original_cwd = Path.cwd()
+        os.chdir(work)
+        try:
+            wt1 = _make_worktree(work, "update-bar", tmp_path)
+            (wt1 / "data.txt").write_text("v2\n")
+            assert svc.commit_changes("update-bar", "Update bar", wt1) is True
+            first_sha = _git(["rev-parse", "origin/update-bar"], cwd=work).strip()
+            _git(["worktree", "remove", "--force", str(wt1)], cwd=work)
+
+            wt2 = _make_worktree(work, "update-bar", tmp_path)
+            (wt2 / "data.txt").write_text("v2\n")
+            assert svc.commit_changes("update-bar", "Update bar v2", wt2) is True
+
+            second_sha = _git(["rev-parse", "origin/update-bar"], cwd=work).strip()
+            assert first_sha != second_sha
+        finally:
+            os.chdir(original_cwd)
+
+    def test_pushes_when_parent_differs(self, tmp_path: Path) -> None:
+        """Same tree+message but different parent should still force push."""
+        work, _remote = _setup_repo_with_remote(tmp_path)
+        svc = OfflineGiteaService()
+        git_env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test User",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test User",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+        original_cwd = Path.cwd()
+        os.chdir(work)
+        try:
+            # First run from current main
+            wt1 = _make_worktree(work, "update-baz", tmp_path)
+            (wt1 / "data.txt").write_text("v2\n")
+            assert svc.commit_changes("update-baz", "Update baz", wt1) is True
+            first_sha = _git(["rev-parse", "origin/update-baz"], cwd=work).strip()
+            _git(["worktree", "remove", "--force", str(wt1)], cwd=work)
+
+            # Advance main with an unrelated commit
+            (work / "other.txt").write_text("unrelated\n")
+            _git(["add", "."], cwd=work)
+            _git(["commit", "-m", "Unrelated"], cwd=work, env=git_env)
+            _git(["push", "origin", "main"], cwd=work)
+
+            # Second run now bases off the new main - same tree contents
+            # for data.txt but different parent
+            wt2 = _make_worktree(work, "update-baz", tmp_path)
+            (wt2 / "data.txt").write_text("v2\n")
+            assert svc.commit_changes("update-baz", "Update baz", wt2) is True
+
+            second_sha = _git(["rev-parse", "origin/update-baz"], cwd=work).strip()
+            assert first_sha != second_sha
+        finally:
+            os.chdir(original_cwd)
+
+    def test_pushes_when_remote_branch_does_not_exist(self, tmp_path: Path) -> None:
+        """First push for a new branch should succeed normally."""
+        work, _remote = _setup_repo_with_remote(tmp_path)
+        svc = OfflineGiteaService()
+        original_cwd = Path.cwd()
+        os.chdir(work)
+        try:
+            wt = _make_worktree(work, "update-new", tmp_path)
+            (wt / "data.txt").write_text("v2\n")
+            assert svc.commit_changes("update-new", "Update new", wt) is True
+
+            # Remote branch should now exist
+            sha = _git(["rev-parse", "origin/update-new"], cwd=work).strip()
+            assert sha
+        finally:
+            os.chdir(original_cwd)


### PR DESCRIPTION
If CI hasn't finished and the branch gets force pushed with the exact same commit that only differs by timestamp, it causes the CI to get cancelled midway and restart the builds which is a total waste of resources

Draft as untested